### PR TITLE
Use smart_text of py3

### DIFF
--- a/todoapp/todos/models.py
+++ b/todoapp/todos/models.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 
 from django.db import models
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text as smart_unicode
 from django.utils.translation import ugettext_lazy as _
 
 


### PR DESCRIPTION
I encountered the following error message regarding `smart_unicode` when I first run the tests:

    Traceback (most recent call last):
      File "manage.py", line 10, in <module>
        execute_from_command_line(sys.argv)
      File "/path/to/python3/lib/python3.6/site-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
        utility.execute()
      File "/path/to/python3/lib/python3.6/site-packages/django/core/management/__init__.py", line 327, in execute
        django.setup()
      File "/path/to/python3/lib/python3.6/site-packages/django/__init__.py", line 18, in setup
        apps.populate(settings.INSTALLED_APPS)
      File "/path/to/python3/lib/python3.6/site-packages/django/apps/registry.py", line 108, in populate
        app_config.import_models(all_models)
      File "/path/to/python3/lib/python3.6/site-packages/django/apps/config.py", line 202, in import_models
        self.models_module = import_module(models_module_name)
      File "/path/to/python3/lib/python3.6/importlib/__init__.py", line 126, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 978, in _gcd_import
      File "<frozen importlib._bootstrap>", line 961, in _find_and_load
      File "<frozen importlib._bootstrap>", line 950, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 678, in exec_module
      File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
      File "/path/to/DRF-TDD-example/todoapp/todos/models.py", line 5, in <module>
        from django.utils.encoding import smart_unicode
    ImportError: cannot import name 'smart_unicode'

`smart_unicode` of Python 2.7 has been renamed to `smart_text` in Python 3 [(source)](https://docs.djangoproject.com/en/1.7/topics/python3/#string-handling).