### PR TITLE
Extend the token-related endpoints

### DIFF
--- a/todoapp/todoapp/urls.py
+++ b/todoapp/todoapp/urls.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 
 api_urls = [
     url(r'^todos/', include('todos.urls')),
-    url(r'^users/', include('users.urls')),
+    url(r'', include('users.urls')),
 ]
 
 urlpatterns = [

--- a/todoapp/users/serializers.py
+++ b/todoapp/users/serializers.py
@@ -52,4 +52,4 @@ class TokenSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Token
-        fields = ("auth_token",)
+        fields = ("auth_token", "created")

--- a/todoapp/users/urls.py
+++ b/todoapp/users/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
-from users.views import UserRegistrationAPIView, UserLoginAPIView, UserLogoutAPIView
+from django.urls import path
+from users.views import UserRegistrationAPIView, UserLoginAPIView, UserTokenAPIView
 
 app_name = 'users'
 
 urlpatterns = [
-    url(r'^$', UserRegistrationAPIView.as_view(), name="list"),
-    url(r'^login/$', UserLoginAPIView.as_view(), name="login"),
-    url(r'^logout/$', UserLogoutAPIView.as_view(), name="logout"),
+    path(r'users/', UserRegistrationAPIView.as_view(), name="list"),
+    path(r'users/login/', UserLoginAPIView.as_view(), name="login"),
+    path(r'tokens/<key>/', UserTokenAPIView.as_view(), name="token"),
 ]

--- a/todoapp/users/views.py
+++ b/todoapp/users/views.py
@@ -2,7 +2,7 @@ from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.generics import CreateAPIView, GenericAPIView
 from rest_framework.response import Response
-from rest_framework.views import APIView
+from rest_framework.generics import RetrieveDestroyAPIView
 from users.serializers import UserRegistrationSerializer, UserLoginSerializer, TokenSerializer
 
 
@@ -46,8 +46,23 @@ class UserLoginAPIView(GenericAPIView):
             )
 
 
-class UserLogoutAPIView(APIView):
+class UserTokenAPIView(RetrieveDestroyAPIView):
+    lookup_field = "key"
+    serializer_class = TokenSerializer
+    queryset = Token.objects.all()
 
-    def post(self, request, *args, **kwargs):
-        Token.objects.filter(user=request.user).delete()
-        return Response(status=status.HTTP_200_OK)
+    def filter_queryset(self, queryset):
+        return queryset.filter(user=self.request.user)
+
+    def retrieve(self, request, key, *args, **kwargs):
+        if key == "current":
+            instance = Token.objects.get(key=request.auth.key)
+            serializer = self.get_serializer(instance)
+            return Response(serializer.data)
+        return super(UserTokenAPIView, self).retrieve(request, key, *args, **kwargs)
+
+    def destroy(self, request, key, *args, **kwargs):
+        if key == "current":
+            Token.objects.get(key=request.auth.key).delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        return super(UserTokenAPIView, self).destroy(request, key, *args, **kwargs)


### PR DESCRIPTION
Implement the `/tokens/<pk>/` endpoint that supports `GET` and `DELETE` HTTP methods. Use the `RetrieveDestroyAPIView` in order to better showcase Django REST framework's capabilities.

Remove the logout endpoint.

Add the `created` field in Token's serializer.