### PR TITLE
Fix: TypeError: the JSON object must be str

### DIFF
--- a/todoapp/todos/tests.py
+++ b/todoapp/todos/tests.py
@@ -32,7 +32,7 @@ class TodoListCreateAPIViewTestCase(APITestCase):
         """
         Todo.objects.create(user=self.user, name="Clean the car!")
         response = self.client.get(self.url)
-        self.assertTrue(len(json.loads(response.content)) == Todo.objects.count())
+        self.assertTrue(len(json.loads(response.content.decode('utf-8'))) == Todo.objects.count())
 
 
 class TodoDetailAPIViewTestCase(APITestCase):
@@ -58,7 +58,7 @@ class TodoDetailAPIViewTestCase(APITestCase):
         self.assertEqual(200, response.status_code)
 
         todo_serializer_data = TodoSerializer(instance=self.todo).data
-        response_data = json.loads(response.content)
+        response_data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(todo_serializer_data, response_data)
 
     def test_todo_object_update_authorization(self):
@@ -79,13 +79,13 @@ class TodoDetailAPIViewTestCase(APITestCase):
 
     def test_todo_object_update(self):
         response = self.client.put(self.url, {"name": "Call Dad!"})
-        response_data = json.loads(response.content)
+        response_data = json.loads(response.content.decode('utf-8'))
         todo = Todo.objects.get(id=self.todo.id)
         self.assertEqual(response_data.get("name"), todo.name)
 
     def test_todo_object_partial_update(self):
         response = self.client.patch(self.url, {"done": True})
-        response_data = json.loads(response.content)
+        response_data = json.loads(response.content.decode('utf-8'))
         todo = Todo.objects.get(id=self.todo.id)
         self.assertEqual(response_data.get("done"), todo.done)
 

--- a/todoapp/users/tests.py
+++ b/todoapp/users/tests.py
@@ -35,7 +35,7 @@ class UserRegistrationAPIViewTestCase(APITestCase):
         }
         response = self.client.post(self.url, user_data)
         self.assertEqual(201, response.status_code)
-        self.assertTrue("token" in json.loads(response.content))
+        self.assertTrue("token" in json.loads(response.content.decode('utf-8')))
 
     def test_unique_username_validation(self):
         """
@@ -80,7 +80,7 @@ class UserLoginAPIViewTestCase(APITestCase):
     def test_authentication_with_valid_data(self):
         response = self.client.post(self.url, {"username": self.username, "password": self.password})
         self.assertEqual(200, response.status_code)
-        self.assertTrue("auth_token" in json.loads(response.content))
+        self.assertTrue("auth_token" in json.loads(response.content.decode('utf-8')))
 
 
 class UserTokenAPIViewTestCase(APITestCase):


### PR DESCRIPTION
Example of error this PR fixes.

```
======================================================================
ERROR: Test to verify that a post call with user valid data
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/amcorreia/Git/amcorreia/Examples/for-Django/amc/DRF-TDD-example/todoapp/users/tests.py", line 38, in test_user_registration
    self.assertTrue("token" in json.loads(response.content))
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```